### PR TITLE
Fix Laplace and EP GLMM when K is available but G is not set

### DIFF
--- a/fastlmm/inference/ep.py
+++ b/fastlmm/inference/ep.py
@@ -56,7 +56,7 @@ class EPGLMM(object):
         converged = False
         outeriter = 1
         iterMax = 1000
-        
+
         while outeriter <= iterMax and not converged:
 
             tau_ = 1.0/prevsig2 - ttau
@@ -156,7 +156,7 @@ class EPGLMM_N1K3(GLMM_N1K3, EPGLMM):
     def _rmll_gradient(self, optSig02=True, optSig12=True, optSign2=True, optBeta=True):
         self._updateConstants()
         self._updateApproximation()
-        
+
         m = self._mean
         H = self._H
         V = self._V
@@ -174,19 +174,19 @@ class EPGLMM_N1K3(GLMM_N1K3, EPGLMM):
         if optSig02:
             r = 0.5*(dot(b, dot(G0, dot(G0.T, b))) - trace2(ddot(V, G0, left=True), G0.T)\
                 + trace2(H.T, dot(dot(H, G0), G0.T)))
-            
+
             ret.append(r)
 
         if optSig12:
             r = 0.5*(dot(b, dot(G1, dot(G1.T, b))) - trace2(ddot(V, G1, left=True), G1.T)\
                 + trace2(H.T, dot(dot(H, G1), G1.T)))
-            
+
             ret.append(r)
 
         if optSign2:
             r = 0.5*(dot(b, b) - NP.sum(V)\
                 + trace2(H.T, H))
-            
+
             ret.append(r)
 
         if optBeta:
@@ -206,21 +206,21 @@ class EPGLMM_N1K3(GLMM_N1K3, EPGLMM):
 
         V = self._calculateV(ttau, sign2)
         G01 = self._G01
-    
+
         Lk = self._calculateLk(G01, V)
-    
+
         G01tV = ddot(G01.T, V, left=False)
         H = stl(Lk, G01tV)
 
         HK = self._ldotK(H)
-    
+
         sig2 = self._dKn() - sign2**2*V - dotd(G01, dot(dot(G01tV, G01), G01.T))\
             - 2.0*sign2*dotd(G01, G01tV) + dotd(HK.T, HK)
 
         assert NP.all(NP.isfinite(sig2)), 'sig2 should be finite.'
 
         u = self._mean + self._rdotK(tnu)
-    
+
         mu = u - self._rdotK(V*u) + self._rdotK(H.T.dot(H.dot(u)))
         assert NP.all(NP.isfinite(mu)), 'mu should be finite.'
 
@@ -262,9 +262,9 @@ class EPGLMM_N3K1(GLMM_N3K1, EPGLMM):
     def _updateApproximationBegin(self):
         self._K = NP.eye(self._N) * self._sign2
         if self._isK0Set:
-            self._K += self._sig02*(dot(self._G0, self._G0.T))
+            self._K += self._sig02*(self._K0 if self._K0 is not None else dot(self._G0, self._G0.T))
         if self._isK1Set:
-            self._K += self._sig12*(dot(self._G1, self._G1.T))
+            self._K += self._sig12*(self._K1 if self._K1 is not None else dot(self._G1, self._G1.T))
 
     def _regular_marginal_loglikelihood(self):
         self._updateConstants()
@@ -329,10 +329,10 @@ class EPGLMM_N3K1(GLMM_N3K1, EPGLMM):
         if optBeta:
             r = -dot(b, self._X)
             ret += list(r)
-            
+
         ret = NP.array(ret)
         assert NP.all(NP.isfinite(ret)), 'Not finite regular marginal loglikelihood gradient.'
-        
+
         return ret
 
     def _updateApproximation(self):

--- a/fastlmm/inference/laplace.py
+++ b/fastlmm/inference/laplace.py
@@ -68,7 +68,7 @@ class LaplaceGLMM(object):
         sig12 = [self._debugUACalls[i].sig12 for i in range(len(self._debugUACalls))]
         sign2 = [self._debugUACalls[i].sign2 for i in range(len(self._debugUACalls))]
         gradMeans = [NP.mean(abs(self._debugUACalls[i].lastGrad)) for i in range(len(self._debugUACalls))]
-        
+
         Pr.prin("*** Update approximation ***")
         Pr.prin("calls: %d" % (len(self._debugUACalls),))
 
@@ -97,7 +97,7 @@ class LaplaceGLMM(object):
         gradEpsStop = 1e-10
         objEpsStop = 1e-8
         gradEpsErr = 1e-3
-        
+
         self._mean = self._calculateMean()
         m = self._mean
 
@@ -157,7 +157,7 @@ class LaplaceGLMM(object):
             failed = True
             failedMsg = 'Gradient not too small in the Laplace update approximation.\n'
             failedMsg = failedMsg+"Problem in the f mode estimation. |grad|_{mean} = %.6f." % (err,)
-       
+
         if ii>=maxIter:
             failed = True
             failedMsg = 'Laplace update approximation did not converge in less than maxIter.'
@@ -275,7 +275,7 @@ class LaplaceGLMM_N1K3(GLMM_N1K3, LaplaceGLMM):
             - 2.0*sign2*dotd(G01, G01tV) + dotd(dkH.T, dkH)) * h
 
         ret = []
-        
+
         if optSig02:
             dK0a = dot(G0, dot(G0.T, a))
             t = V*dK0a - dot(H.T, dot(H, dK0a))
@@ -287,7 +287,7 @@ class LaplaceGLMM_N1K3(GLMM_N1K3, LaplaceGLMM):
             ret0 = dot(a, dF0) - 0.5*dot(a, dK0a) + dot(f-m, t)\
                 + 0.5*NP.sum( diags*dF0 )\
                 + -0.5*trace2(VG0, G0.T) + 0.5*trace2( LkG01VG0.T, LkG01VG0 )
-            
+
             ret.append(ret0)
 
         if optSig12:
@@ -301,7 +301,7 @@ class LaplaceGLMM_N1K3(GLMM_N1K3, LaplaceGLMM):
             ret1 = dot(a, dF1)- 0.5*dot(a, dK1a) + dot(f-m, t)\
                 + 0.5*NP.sum( diags*dF1 )\
                 + -0.5*trace2(VG1, G1.T) + 0.5*trace2( LkG01VG1.T, LkG01VG1 )
-            
+
             ret.append(ret1)
 
         if optSign2:
@@ -311,7 +311,7 @@ class LaplaceGLMM_N1K3(GLMM_N1K3, LaplaceGLMM):
             retn = dot(a, dFn)- 0.5*dot(a, a) + dot(f-m, t)\
                 + 0.5*NP.sum( diags*dFn )\
                 + -0.5*NP.sum(V) + 0.5*trace2( H.T, H )
-            
+
             ret.append(retn)
 
         if optBeta:
@@ -326,7 +326,7 @@ class LaplaceGLMM_N1K3(GLMM_N1K3, LaplaceGLMM):
 
         ret = NP.array(ret)
         assert NP.all(NP.isfinite(ret)), 'Not finite regular marginal loglikelihood gradient.'
-        
+
         return ret
 
     def _predict(self, meanstar, kstar, kstarstar, prob):
@@ -339,7 +339,7 @@ class LaplaceGLMM_N1K3(GLMM_N1K3, LaplaceGLMM):
         --------------------------------------------------------------------------
         Input:
         meanstar        : input mean.
-        kstar           : covariance between provided and prior latent variables. 
+        kstar           : covariance between provided and prior latent variables.
         xstarstar       : variance of the latent variable.
         prob            : True for probability calculation or False for returning
                           the most probable label.
@@ -370,9 +370,9 @@ class LaplaceGLMM_N3K1(GLMM_N3K1, LaplaceGLMM):
     def _updateApproximationBegin(self):
         self._K = NP.eye(self._N) * self._sign2
         if self._isK0Set:
-            self._K += self._sig02*(dot(self._G0, self._G0.T))
+            self._K += self._sig02*(self._K0 if self._K0 is not None else dot(self._G0, self._G0.T))
         if self._isK1Set:
-            self._K += self._sig12*(dot(self._G1, self._G1.T))
+            self._K += self._sig12*(self._K1 if self._K1 is not None else dot(self._G1, self._G1.T))
 
     def _calculateUAa(self, b, W):
         Wsq = NP.sqrt(W)
@@ -471,7 +471,7 @@ class LaplaceGLMM_N3K1(GLMM_N3K1, LaplaceGLMM):
 
         ret = NP.array(ret)
         assert NP.all(NP.isfinite(ret)), 'Not finite regular marginal loglikelihood gradient.'
-        
+
         return ret
 
     def _updateApproximation(self):
@@ -487,7 +487,7 @@ class LaplaceGLMM_N3K1(GLMM_N3K1, LaplaceGLMM):
         --------------------------------------------------------------------------
         Input:
         meanstar        : input mean.
-        kstar           : covariance between provided and prior latent variables. 
+        kstar           : covariance between provided and prior latent variables.
         xstarstar       : variance of the latent variable.
         prob            : True for probability calculation or False for returning
                           the most probable label.


### PR DESCRIPTION
Current version has this bug for both Laplace and EP versions of GLMM:

```
from numpy import dot, zeros
from numpy.random import RandomState
random = RandomState(0)
nsamples = 10
X = random.randn(nsamples, 2)
G = random.randn(nsamples, 100)
K = dot(G, G.T)
y = zeros(nsamples)
y[1:5] = 1
from fastlmm.inference.ep import EPGLMM_N3K1 as GLMM_Method
model = GLMM_Method('logistic')
model.setX(X)
model.setK(K)
model.sety(y)
model.optimize()
```
output:
```
    self._K += self._sig02*(dot(self._G0, self._G0.T))
AttributeError: 'NoneType' object has no attribute 'T'
```

This patch fixes them.