### PR TITLE
Add unit test for #2

### DIFF
--- a/fastlmm/inference/ep.py
+++ b/fastlmm/inference/ep.py
@@ -8,6 +8,7 @@ from fastlmm.external.util.math import check_definite_positiveness,check_symmetr
 from fastlmm.external.util.math import stl, stu, dotd
 from fastlmm.inference.glmm import GLMM_N1K3, GLMM_N3K1
 from fastlmm.inference.likelihood import LogitLikelihood, ProbitLikelihood
+from fastlmm import Pr
 from . import likelihood as LH
 
 

--- a/fastlmm/inference/laplace.py
+++ b/fastlmm/inference/laplace.py
@@ -9,6 +9,7 @@ from fastlmm.external.util.math import check_definite_positiveness,check_symmetr
 from fastlmm.external.util.math import stl, stu
 from fastlmm.inference.glmm import GLMM_N1K3, GLMM_N3K1
 from fastlmm.inference.likelihood import LogitLikelihood, ProbitLikelihood
+from fastlmm import Pr
 import sys
 from six.moves import range
 

--- a/fastlmm/inference/tests/test.py
+++ b/fastlmm/inference/tests/test.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import numpy as NP
 import scipy as SP
 import scipy.io as SIO
-import scipy.linalg as LA 
+import scipy.linalg as LA
 from fastlmm.inference.laplace import LaplaceGLMM_N3K1, LaplaceGLMM_N1K3
 from fastlmm.inference.ep import EPGLMM_N3K1, EPGLMM_N1K3
 from fastlmm.inference import getLMM
@@ -32,12 +32,12 @@ class TestLmmKernel(unittest.TestCase):
         self._G0 = randomstate.randn(self._N,self._k0)
         self._G1 = randomstate.randn(self._N,self._k1)
         self._y = randomstate.randn(self._N)
-      
+
         self._Xstar = randomstate.randn(self._M,self._D)
         self._G0star = randomstate.randn(self._M,self._k0)
         self._G1star = randomstate.randn(self._M,self._k1)
 
-    
+
     def test_predictions(self):
         model = getLMM()
         model.setG(G0=self._G0,G1=self._G1,a2=self._a2)
@@ -52,7 +52,7 @@ class TestLmmKernel(unittest.TestCase):
         ystar2 = SP.dot(self._Xstar,self._beta) + SP.dot(Gstar,weights)
         self.assertAlmostEqual(ystar[0],ystar2[0])
         self.assertAlmostEqual(ystar[1],ystar2[1])
-    
+
         # h2 space
         #TODO: this passes on the above toy data but fails on realistic data, fix!
         #h2 = 0.5
@@ -61,36 +61,36 @@ class TestLmmKernel(unittest.TestCase):
         #ystar2 = SP.dot(self._Xstar,self._beta) + SP.dot(Gstar,weights)
         #self.assertAlmostEqual(ystar[0],ystar2[0])
         #self.assertAlmostEqual(ystar[1],ystar2[1])
-    
-    
+
+
     def test_nLLeval_1(self):
         """
         small regression test to check negative log likelihood function
-        
+
         delta = 1, REML = False
         """
-        
+
         model = getLMM()
         model.setG(G0=self._G0, G1=self._G1, a2=self._a2)
         model.setX(self._X)
         model.sety(self._y)
         result = model.nLLeval(REML=False,delta=1.0)
-        
+
         target_result = {'scale': 1.0, 'h2': 0.0, 'beta': NP.array([ 0.05863443]), 'a2': 0.4, 'REML': False, 'nLL': 91.92983775736522, 'sigma2': 0.94826207355429604}
-        
+
         # make sure results are the same
         for key in result.keys():
             NP.testing.assert_array_almost_equal(result[key], target_result[key])
             #self.assertAlmostEqual(result[key], target_result[key])
 
-        
+
     def test_nLLeval_2(self):
         """
         small regression test to check negative log likelihood function
-        
+
         delta = 1, REML = True
         """
-        
+
         model = getLMM()
         model.setG(G0=self._G0, G1=self._G1 ,a2=self._a2)
         model.setX(self._X)
@@ -102,17 +102,17 @@ class TestLmmKernel(unittest.TestCase):
         for key in result.keys():
             NP.testing.assert_array_almost_equal(result[key], target_result[key])
             #self.assertAlmostEqual(result[key], target_result[key])
-         
-         
-         
-         
+
+
+
+
     def test_nLLeval_3(self):
         """
         small regression test to check negative log likelihood function
-        
+
         delta = None, h2 = 0.5, REML = True
         """
-        
+
         model = getLMM()
         model.setG(G0=self._G0,G1=self._G1,a2=self._a2)
         model.setX(self._X)
@@ -124,24 +124,24 @@ class TestLmmKernel(unittest.TestCase):
         for key in result.keys():
             NP.testing.assert_array_almost_equal(result[key], target_result[key])
             #self.assertAlmostEqual(result[key], target_result[key])
-            
-        
-class TestProximalContamination(unittest.TestCase):     
 
-    
+
+class TestProximalContamination(unittest.TestCase):
+
+
     def test_one_kernel_fullrank(self):
         """
         test for one kernel only, using delta=1.0, REML=False
         """
         delta = 1.0
-    
+
         # full rank as N <= s_c
         N = 10 # number of individuals
         d = 1 # number of fix effects
         s_c = 40 # number of SNPs used to construct the genetic similarity matrix
-        
+
         X, y, G0, G1, G0_small, exclude_idx = generate_random_data(N, d, s_c)
-    
+
         lmm_nocut = getLMM()
         lmm_nocut.setG(G0_small)
         lmm_nocut.setX(X)
@@ -151,14 +151,14 @@ class TestProximalContamination(unittest.TestCase):
         lmm_nocut.setTestData(Xstar=X[:3],K0star=None,K1star=None,G0star=G0_small[:3],G1star=None)
 
         ypred_nocut = lmm_nocut.predictMean(beta=ret_nocut['beta'],delta=delta)
-        
+
         lmm_cut = getLMM()
         lmm_cut.setG(G0)
         lmm_cut.setX(X)
         lmm_cut.sety(y)
         lmm_cut.set_exclude_idx(exclude_idx)
         ret_cut = lmm_cut.nLLeval(REML=False,delta=delta)
-        
+
         lmm_cut.setTestData(Xstar=X[:3],G0star=G0[:3])
         ypred_cut = lmm_cut.predictMean(beta=ret_cut['beta'],delta=delta)
 
@@ -166,191 +166,191 @@ class TestProximalContamination(unittest.TestCase):
         for key in ret_nocut.keys():
             NP.testing.assert_array_almost_equal(ret_cut[key], ret_nocut[key])
             #self.assertAlmostEqual(ret_cut[key], ret_nocut[key])
-    
+
         wproj = SP.random.randn(ypred_nocut.shape[0])
         self.assertAlmostEqual((wproj*ypred_nocut).sum(),(wproj*ypred_cut).sum())
-    
+
 
     def test_one_kernel_lowrank(self):
         """
         test for one kernel only, using delta=1.0, REML=False
         """
         delta = 1.0
-    
+
         # low rank as N > s_c
         N = 100 # number of individuals
         d = 1 # number of fix effects
         s_c = 40 # number of SNPs used to construct the genetic similarity matrix
-        
+
         X, y, G0, G1, G0_small, exclude_idx = generate_random_data(N, d, s_c)
-    
+
         lmm_nocut = getLMM()
         lmm_nocut.setG(G0_small)
         lmm_nocut.setX(X)
         lmm_nocut.sety(y)
-        
+
         ret_nocut = lmm_nocut.nLLeval(REML=False,delta=delta)
         lmm_nocut.setTestData(Xstar=X[:3],G0star=G0_small[:3])
         ypred_nocut = lmm_nocut.predictMean(beta=ret_nocut['beta'],delta=delta)
-        
+
         lmm_cut = getLMM()
         lmm_cut.setG(G0)
         lmm_cut.setX(X)
         lmm_cut.sety(y)
         lmm_cut.set_exclude_idx(exclude_idx)
-        
+
         ret_cut = lmm_cut.nLLeval(REML=False,delta=delta)
         lmm_cut.setTestData(Xstar=X[:3],G0star=G0[:3])
         ypred_cut = lmm_cut.predictMean(beta=ret_cut['beta'],delta=delta)
-        
+
         # make sure results are the same
         for key in ret_nocut.keys():
             NP.testing.assert_array_almost_equal(ret_cut[key], ret_nocut[key])
             #self.assertAlmostEqual(ret_cut[key], ret_nocut[key])
-    
+
         wproj = SP.random.randn(ypred_nocut.shape[0])
         self.assertAlmostEqual((wproj*ypred_nocut).sum(),(wproj*ypred_cut).sum())
-    
+
     def test_two_kernels_fullrank(self):
         """
         two kernels, using delta=1.0, REML=False
         """
         delta = 1.0
-    
+
         # full rank as N <= s_c
         N = 10 # number of individuals
         d = 1 # number of fix effects
         s_c = 40 # number of SNPs used to construct the genetic similarity matrix
-        
+
         X, y, G0, G1, G0_small, exclude_idx = generate_random_data(N, d, s_c)
-    
+
         lmm_nocut = getLMM()
         lmm_nocut.setG(G0_small, G1)
         lmm_nocut.setX(X)
         lmm_nocut.sety(y)
-        
+
         ret_nocut = lmm_nocut.nLLeval(REML=False,delta=delta)
         lmm_nocut.setTestData(Xstar=X[:3],G0star=G0_small[:3],G1star=G1[:3])
         ypred_nocut = lmm_nocut.predictMean(beta=ret_nocut['beta'],delta=delta)
-        
+
         lmm_cut = getLMM()
         lmm_cut.setG(G0, G1)
         lmm_cut.setX(X)
         lmm_cut.sety(y)
         lmm_cut.set_exclude_idx(exclude_idx)
-        
+
         ret_cut = lmm_cut.nLLeval(REML=False,delta=delta)
         lmm_cut.setTestData(Xstar=X[:3],G0star=G0[:3],G1star=G1[:3])
         ypred_cut = lmm_cut.predictMean(beta=ret_cut['beta'],delta=delta)
-        
+
         # make sure results are the same
         for key in ret_nocut.keys():
             NP.testing.assert_array_almost_equal(ret_cut[key], ret_nocut[key])
             #self.assertAlmostEqual(ret_cut[key], ret_nocut[key])
         wproj = SP.random.randn(ypred_nocut.shape[0])
         self.assertAlmostEqual((wproj*ypred_nocut).sum(),(wproj*ypred_cut).sum())
-            
+
     def test_two_kernels_lowrank(self):
         """
         two kernels, using delta=1.0, REML=False
         """
         delta = 1.0
-    
+
         # low rank as N > s_c
         N = 100 # number of individuals
         d = 1 # number of fix effects
         s_c = 40 # number of SNPs used to construct the genetic similarity matrix
-        
+
         X, y, G0, G1, G0_small, exclude_idx = generate_random_data(N, d, s_c)
-    
+
         lmm_nocut = getLMM()
         lmm_nocut.setG(G0_small, G1)
         lmm_nocut.setX(X)
         lmm_nocut.sety(y)
-        
+
         ret_nocut = lmm_nocut.nLLeval(REML=False,delta=delta)
         lmm_nocut.setTestData(Xstar=X[:3],G0star=G0_small[:3],G1star=G1[:3])
         ypred_nocut = lmm_nocut.predictMean(beta=ret_nocut['beta'],delta=delta)
-        
+
         lmm_cut = getLMM()
         lmm_cut.setG(G0, G1)
         lmm_cut.setX(X)
         lmm_cut.sety(y)
         lmm_cut.set_exclude_idx(exclude_idx)
-        
+
         ret_cut = lmm_cut.nLLeval(REML=False,delta=delta)
         lmm_cut.setTestData(Xstar=X[:3],G0star=G0[:3],G1star=G1[:3])
         ypred_cut = lmm_cut.predictMean(beta=ret_cut['beta'],delta=delta)
-        
+
         # make sure results are the same
         for key in ret_nocut.keys():
             NP.testing.assert_array_almost_equal(ret_cut[key], ret_nocut[key])
             #self.assertAlmostEqual(ret_cut[key], ret_nocut[key])
         wproj = SP.random.randn(ypred_nocut.shape[0])
         self.assertAlmostEqual((wproj*ypred_nocut).sum(),(wproj*ypred_cut).sum())
-    
+
     def test_two_kernels_fullrank_REML(self):
         """
         two kernels, using delta=1.0, REML=True
         """
         delta = 2.0
-    
+
         # full rank as N <= s_c
         N = 10 # number of individuals
         d = 1 # number of fix effects
         s_c = 40 # number of SNPs used to construct the genetic similarity matrix
-        
+
         X, y, G0, G1, G0_small, exclude_idx = generate_random_data(N, d, s_c)
-    
+
         lmm_nocut = getLMM()
         lmm_nocut.setG(G0_small, G1)
         lmm_nocut.setX(X)
         lmm_nocut.sety(y)
-        
+
         ret_nocut = lmm_nocut.nLLeval(REML=True,delta=delta)
-        
+
         lmm_cut = getLMM()
         lmm_cut.setG(G0, G1)
         lmm_cut.setX(X)
         lmm_cut.sety(y)
         lmm_cut.set_exclude_idx(exclude_idx)
-        
+
         ret_cut = lmm_cut.nLLeval(REML=True,delta=delta)
 
         # make sure results are the same
         for key in ret_nocut.keys():
             NP.testing.assert_array_almost_equal(ret_cut[key], ret_nocut[key])
             #self.assertAlmostEqual(ret_cut[key], ret_nocut[key])
-            
-            
+
+
     def test_two_kernels_lowrank_REML(self):
         """
         two kernels, using delta=1.0, REML=True
         """
         delta = 0.5
-    
+
         # low rank as N > s_c
         N = 100 # number of individuals
         d = 1 # number of fix effects
         s_c = 40 # number of SNPs used to construct the genetic similarity matrix
-        
+
         X, y, G0, G1, G0_small, exclude_idx = generate_random_data(N, d, s_c)
-    
+
         lmm_nocut = getLMM()
         lmm_nocut.setG(G0_small, G1)
         lmm_nocut.setX(X)
         lmm_nocut.sety(y)
-        
+
         ret_nocut = lmm_nocut.nLLeval(REML=True,delta=delta)
-        
+
         lmm_cut = getLMM()
         lmm_cut.setG(G0, G1)
         lmm_cut.setX(X)
         lmm_cut.sety(y)
         lmm_cut.set_exclude_idx(exclude_idx)
-        
+
         ret_cut = lmm_cut.nLLeval(REML=True,delta=delta)
-        
+
         # make sure results are the same
         for key in ret_nocut.keys():
             NP.testing.assert_array_almost_equal(ret_cut[key], ret_nocut[key])
@@ -360,23 +360,23 @@ def generate_random_data(N, d, s_c):
     """
     small helper to generate a random data set
     """
-    
+
 
     num_excludes = s_c // 2
     s = s_c # total number of SNPs to be tested
-    
+
     X = NP.ones((N, d))
     y = NP.random.rand(N)
-    
+
     G0 = NP.random.rand(N, s_c)
     G1 = NP.random.rand(N, s)
-    
+
     # exclude randomly
     perm = SP.random.permutation(s_c)
     exclude_idx = perm[:num_excludes]
     include_idx = perm[num_excludes:]
     G0_small = G0[:,include_idx]
-    
+
 
     return X, y, G0, G1, G0_small, exclude_idx
 
@@ -491,6 +491,31 @@ class TestBin2Kernel(unittest.TestCase):
 
         self.assertAlmostEqual(-6.7545709287754718, model._regular_marginal_loglikelihood())
 
+    def test_setK_rmargll_after_optimization(self):
+        model = LaplaceGLMM_N3K1('logistic')
+        model.setK(NP.dot(self._G0, self._G0.T), NP.dot(self._G1, self._G1.T))
+        model.setX(self._X)
+        model.sety(self._y)
+        model.sig02 = 1.5
+        model.sig12 = 0.5
+        model.sign2 = 0.8
+        model.beta = NP.array([2.0, -1.0])
+        model.optimize()
+
+        self.assertAlmostEqual(-6.75677866924, model._regular_marginal_loglikelihood())
+
+        model = EPGLMM_N3K1('erf')
+        model.setK(NP.dot(self._G0, self._G0.T), NP.dot(self._G1, self._G1.T))
+        model.setX(self._X)
+        model.sety(self._y)
+        model.sig02 = 1.5
+        model.sig12 = 0.5
+        model.sign2 = 0.8
+        model.beta = NP.array([2.0, -1.0])
+        model.optimize()
+
+        self.assertAlmostEqual(-6.75424440734, model._regular_marginal_loglikelihood())
+
     def test_rmargll_gradient(self):
         def func(x, model):
             model.sig02 = x[0]
@@ -559,7 +584,7 @@ class TestBin2Kernel(unittest.TestCase):
 
         ps = NP.array([0.30481858,0.22520247,0.78060709,0.44734337,0.58824651,0.052388,\
                        0.60337951,0.22886631,0.54169641,0.71888192])
-        
+
         p = model.predict(self._X, self._G0, self._G1)
         for i in range(ps.shape[0]):
             self.assertAlmostEqual(ps[i], p[i], places=4)
@@ -694,7 +719,7 @@ def getTestSuite():
     """
     set up composite test suite
     """
-    
+
     suite1 = unittest.TestLoader().loadTestsFromTestCase(TestBin2Kernel)
     suite2 = unittest.TestLoader().loadTestsFromTestCase(TestProximalContamination)
     suite3 = unittest.TestLoader().loadTestsFromTestCase(TestLmmKernel)


### PR DESCRIPTION
Sorry for the trailing whitespace removal from my text editor but here I simply copied one of the test and replaced `setG` with `setK`. Without #2 it fails:

```
======================================================================
ERROR: test_setK_rmargll_after_optimization (__main__.TestBin2Kernel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test.py", line 503, in test_setK_rmargll_after_optimization
...
    self._K += self._sig02*(dot(self._G0, self._G0.T))
AttributeError: 'NoneType' object has no attribute 'T'

----------------------------------------------------------------------
Ran 21 tests in 4.531s

FAILED (errors=1)
```

and with #2 the test passes.

*Update*: I also added a commit to import `Pr` so the functional call `Pr.prin()` will work. 