### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/fastlmm/association/tests/test_snp_set.py
+++ b/fastlmm/association/tests/test_snp_set.py
@@ -142,7 +142,7 @@ class TestSnpSet(unittest.TestCase):
             return windows_fn 
 
 
-    def test_doctest(self):
+    def test_doctest_two(self):
         old_dir = os.getcwd()
         os.chdir(os.path.dirname(os.path.realpath(__file__))+"/..")
         result = doctest.testmod(sys.modules['fastlmm.association.snp_set'])


### PR DESCRIPTION
Fixes #22.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

