### PR TITLE
Support cbgen>=1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ scikit-learn>=0.19.1
 cloudpickle>=2.2.0
 statsmodels>=0.10.1
 psutil>=5.6.7
-cbgen==1.0.1
+cbgen>=1.0.1
 pysnptools>=0.5.7
 fastlmmclib>=0.0.2


### PR DESCRIPTION
@CarlKCarlK thank you so much for adding support for ``cbgen==1.0.2`` in PySnpTools! I thought while we're on this topic I may also ask for implementing a fix similar to  https://github.com/fastlmm/PySnpTools/pull/4 also for FaST-LMM. If that's possible that would be great.